### PR TITLE
fix video-render when user sets craft or sticks size to 0%

### DIFF
--- a/js/flightlog_video_renderer.js
+++ b/js/flightlog_video_renderer.js
@@ -182,8 +182,8 @@ function FlightLogVideoRenderer(flightLog, logParameters, videoOptions, events) 
             renderFrame = function() {
                 graph.render(frameTime);
                 
-                if(logParameters.hasSticks) canvasContext.drawImage(stickCanvas, stickCanvasLeft, stickCanvasTop);
-                if(logParameters.hasCraft) canvasContext.drawImage(craftCanvas, craftCanvasLeft, craftCanvasTop);
+                if ((logParameters.hasSticks) && (parseInt(userSettings.sticks.size)>0)) canvasContext.drawImage(stickCanvas, stickCanvasLeft, stickCanvasTop);
+                if ((logParameters.hasCraft) && (parseInt(userSettings.craft.size)>0)) canvasContext.drawImage(craftCanvas, craftCanvasLeft, craftCanvasTop);
                 if(logParameters.hasAnalyser) canvasContext.drawImage(analyserCanvas, analyserCanvasLeft, analyserCanvasTop);
                 
                 videoWriter.addFrame(canvas);


### PR DESCRIPTION
* simplest fix for BF's #425 https://github.com/betaflight/blackbox-log-viewer/issues/425
* only renders craft or sticks when user set size is > 0% (thus fixing stuck calculating bug)