### PR TITLE
[gh actions] use date as tag for dev-unstable dev-master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
           echo "Repo: ${{ github.REPOSITORY }}"
           echo "outputs.buildtag: ${{ needs.build.outputs.buildtag }}"
           echo "outputs.shortsha: ${{ needs.build.outputs.shortsha }}"
+          echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
         continue-on-error: true
 
       - name: download artifacts
@@ -138,7 +139,7 @@ jobs:
           repo: dev-unstable
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "bbe-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-bbe"
           draft: true
           prerelease: true
           allowUpdates: true
@@ -169,7 +170,7 @@ jobs:
           repo: dev-master
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "bbe-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-bbe"
           draft: true
           prerelease: true
           allowUpdates: true


### PR DESCRIPTION
use datestamp as tag for dev-unstable dev-master
![image](https://github.com/emuflight/EmuFlight-Blackbox-Explorer/assets/56646290/1a0a45d3-0431-4bdf-84e4-7dbb412cfb48)

not build number which loses sorting
![image](https://github.com/emuflight/EmuFlight-Blackbox-Explorer/assets/56646290/4a8c5e2e-f5a1-4d27-a468-9cd98d127599)
