### PR TITLE
Add gyroUnfilt field support (labels + graph scaling)

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -56,6 +56,11 @@ function FlightLogFieldPresenter() {
         'gyroADC[1]': 'Gyro [pitch]',
         'gyroADC[2]': 'Gyro [yaw]',
 
+        'gyroUnfilt[all]': 'Unfiltered Gyros',
+        'gyroUnfilt[0]': 'Unfiltered Gyro [roll]',
+        'gyroUnfilt[1]': 'Unfiltered Gyro [pitch]',
+        'gyroUnfilt[2]': 'Unfiltered Gyro [yaw]',
+
         //End-users prefer 1-based indexing
         'motor[all]': 'Motors',
         'motor[0]': 'Motor [1]',
@@ -786,6 +791,9 @@ function FlightLogFieldPresenter() {
             case 'gyroADC[0]':
             case 'gyroADC[1]':
             case 'gyroADC[2]':
+            case 'gyroUnfilt[0]':
+            case 'gyroUnfilt[1]':
+            case 'gyroUnfilt[2]':
                 return flightLog.gyroRawToDegreesPerSecond(value / highResolutionScale).toFixed(highResolutionAddPrecision) + " deg/s";
                 
             case 'gyroADCs[0]':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -180,6 +180,8 @@ GraphConfig.load = function(config) {
                 return 5000;
             } else if (fieldName.match(/^gyroADC.*\[/)) {
                 return 3000;
+            } else if (fieldName.match(/^gyroUnfilt.*\[/)) {
+                return 3000;
             } else if (fieldName.match(/^accSmooth\[/)) {
                 return 3000;
             } else if (fieldName.match(/^axis.+\[/)) {
@@ -299,7 +301,8 @@ GraphConfig.load = function(config) {
                 };
             } else if (fieldName.match(/^axisError\[/)  ||     // Gyro, Gyro Scaled, RC Command Scaled and axisError
                        fieldName.match(/^rcCommands\[/) ||     // These use the same scaling as they are in the
-                       fieldName.match(/^gyroADC\[/)) {        // same range.
+                       fieldName.match(/^gyroADC\[/) ||        // same range.
+                       fieldName.match(/^gyroUnfilt\[/)) {
                 return {
                     offset: 0,
                     power: 0.25, /* Make this 1.0 to scale linearly */


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Adds friendly labels and case handling for `gyroUnfilt[0..2]` in `js/flightlog_fields_presenter.js`, matching the existing `gyroADC` entries.
- Adds `gyroUnfilt` to the smoothing and inputRange/outputRange scale groups in `js/graph_config.js`, matching `gyroADC`.

## Background

`gyroUnfilt` (EmuFlight PR #1331, `emuflight/EmuFlight`) reports the same pre-scaled deg/s values as `debug[]` under `debug_mode=GYRO_SCALED`. This viewer has no source-level awareness of the field: it falls back to the raw field name as a label and a generic linear auto-ranged curve, so `gyroUnfilt` renders differently from `Gyro Scaled` in the UI despite identical underlying samples.

Resolves #45

## CI note

This repo's CI (`Build EmuFlight-BlackBox-Explorer` workflow) is currently failing on unrelated dependency/Node-version issues (Node 16 pinned, transitive deps require Node ≥18) tracked in #42 (NW.js → Electron/Forge migration). CI is expected to fail on this PR for that pre-existing reason, unrelated to this change. Opening this now to have the correct field-support code recorded upstream regardless of CI status.

## Test plan

- [x] `node -c js/graph_config.js` — syntax check passes
- [x] `node -c js/flightlog_fields_presenter.js` — syntax check passes
- [x] Verified against a local patched build of the installed binary: opening a log with `gyroUnfilt` fields shows `Unfiltered Gyro [roll/pitch/yaw]` labels using the same curve/scale as `Gyro Scaled`
- [ ] Maintainer review of scale/grouping choices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for displaying unfiltered gyro data with friendly labels.
  * Unfiltered gyro readings are now converted and formatted in degrees per second.
  * Added default smoothing and curve scaling for unfiltered gyro fields in graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->